### PR TITLE
Updated French translation

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: length\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-18 16:12+0100\n"
-"PO-Revision-Date: 2025-03-18 09:08+0100\n"
+"PO-Revision-Date: 2025-03-18 09:13+0100\n"
 "Last-Translator: Hervé Quatremain\n"
 "Language-Team: none\n"
 "Language: fr\n"
@@ -410,7 +410,9 @@ msgstr "D’accord"
 #. and optionally an email or URL.
 #: src/main.py:153
 msgid "translator-credits"
-msgstr "Hervé Quatremain"
+msgstr ""
+"Hervé Quatremain,\n"
+"Irénée Thirion"
 
 #: src/preferences.py:149
 msgid "Select Font"

--- a/po/fr.po
+++ b/po/fr.po
@@ -141,7 +141,7 @@ msgstr "Orientation de gauche à droite"
 msgid ""
 "Display the scale from left to right when TRUE, else from right to left."
 msgstr ""
-"La sera affichée de gauche à droite si l’option est définie sur VRAI, sinon "
+"La règle sera affichée de gauche à droite si l’option est définie sur VRAI, sinon "
 "de droite à gauche."
 
 #: data/io.github.herve4m.Length.gschema.xml.in:74

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: length\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-18 16:12+0100\n"
-"PO-Revision-Date: 2025-01-18 13:44+0100\n"
+"PO-Revision-Date: 2025-03-18 09:08+0100\n"
 "Last-Translator: Hervé Quatremain\n"
 "Language-Team: none\n"
 "Language: fr\n"
@@ -16,33 +16,34 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 3.5\n"
 
 #: data/io.github.herve4m.Length.desktop.in.in:3
 #: data/io.github.herve4m.Length.metainfo.xml.in.in:7
 msgid "Length"
-msgstr "Length"
+msgstr "Longueur"
 
 #: data/io.github.herve4m.Length.desktop.in.in:4
 msgid "Screen ruler"
-msgstr "Règle d'écran"
+msgstr "Règle d’écran"
 
 #: data/io.github.herve4m.Length.desktop.in.in:5
 #: data/io.github.herve4m.Length.metainfo.xml.in.in:8
 msgid "Measure objects on screen"
-msgstr "Mesure d'objects à l'écran"
+msgstr "Mesurer des objets à l’écran"
 
 #: data/io.github.herve4m.Length.desktop.in.in:11
 msgid "GTK;GNOME;ruler;measure;"
-msgstr "GTK;GNOME;règle;mesure;"
+msgstr "GTK;GNOME;règle;mesurer;"
 
 #: data/io.github.herve4m.Length.metainfo.xml.in.in:10
 msgid ""
 "GNOME application for measuring distances on screen to help you design and "
 "inspect layouts and graphics. Length includes the following features:"
 msgstr ""
-"Programme GNOME pour mesurer des distances à l'écran pour vous aider à "
-"concevoir et inspecter mises en page et graphiques. Length comprend les "
-"fonctionnalités suivantes :"
+"Une application pour GNOME pour mesurer des distances à l’écran et vous "
+"aider à concevoir et inspecter mises en page et graphiques. Longueur "
+"comprend les fonctionnalités suivantes :"
 
 #: data/io.github.herve4m.Length.metainfo.xml.in.in:15
 msgid "Pixels, centimeters, inches, picas, points, or percentages as units"
@@ -66,15 +67,15 @@ msgstr "Suivi de la position du pointeur"
 
 #: data/io.github.herve4m.Length.metainfo.xml.in.in:45
 msgid "Horizontal view of Length with pixels as units"
-msgstr "Length en pixels en position horizontale"
+msgstr "Longueur en pixels en position horizontale"
 
 #: data/io.github.herve4m.Length.metainfo.xml.in.in:49
 msgid "Vertical view of Length with inches as units"
-msgstr "Length en pouces en position verticale"
+msgstr "Longueur en pouces en position verticale"
 
 #: data/io.github.herve4m.Length.metainfo.xml.in.in:53
 msgid "Length main menu"
-msgstr "Menu principal de Length"
+msgstr "Menu principal de Longueur"
 
 #: data/io.github.herve4m.Length.metainfo.xml.in.in:57
 msgid "Preferences window"
@@ -102,15 +103,15 @@ msgstr "Suivre le pointeur"
 
 #: data/io.github.herve4m.Length.gschema.xml.in:33
 msgid "Display the pointer position in the ruler."
-msgstr "Affiche la position du pointeur sur la règle."
+msgstr "Afficher la position du pointeur sur la règle."
 
 #: data/io.github.herve4m.Length.gschema.xml.in:38
 msgid "Origin of the Ruler"
-msgstr "Point d'origine"
+msgstr "Point d’origine"
 
 #: data/io.github.herve4m.Length.gschema.xml.in:39
 msgid "Point of origin in ruler units."
-msgstr "Point d'origine dans l'unité de la règle."
+msgstr "Point d’origine dans l’unité de la règle."
 
 #: data/io.github.herve4m.Length.gschema.xml.in:44
 msgid "Monitor Calibration Parameters"
@@ -121,8 +122,8 @@ msgid ""
 "For each monitor, specify whether to let the ruler retrieve the monitor size "
 "from the system, or use the provided monitor size for the computations."
 msgstr ""
-"Indique pour chaque écran si Length obtient la taille de l'écran du système, "
-"ou si les calculs sont fait à partir de la taille d'écran fourni."
+"Indique pour chaque écran si Longueur obtient la taille de l’écran du "
+"système, ou si les calculs sont fait à partir de la taille d’écran fourni."
 
 #: data/io.github.herve4m.Length.gschema.xml.in:60
 msgid "Ruler Unit"
@@ -130,7 +131,7 @@ msgstr "Unités de la règle"
 
 #: data/io.github.herve4m.Length.gschema.xml.in:61
 msgid "Unit to use for the ruler"
-msgstr "Unitè à utiliser pour la règle"
+msgstr "Unités à utiliser pour la règle"
 
 #: data/io.github.herve4m.Length.gschema.xml.in:66
 msgid "Direction from Left to Right"
@@ -140,7 +141,8 @@ msgstr "Orientation de gauche à droite"
 msgid ""
 "Display the scale from left to right when TRUE, else from right to left."
 msgstr ""
-"Afficher la règle de gauche à droite si VRAI, sinon de droite à gauche."
+"La sera affichée de gauche à droite si l’option est définie sur VRAI, sinon "
+"de droite à gauche."
 
 #: data/io.github.herve4m.Length.gschema.xml.in:74
 msgid "Use default font"
@@ -148,7 +150,7 @@ msgstr "Utiliser la police par défaut"
 
 #: data/io.github.herve4m.Length.gschema.xml.in:75
 msgid "Whether to use the default font"
-msgstr "Utiliser ou non la police par défaut"
+msgstr "Indique s’il faut utiliser ou non la police par défaut"
 
 #: data/io.github.herve4m.Length.gschema.xml.in:80
 msgid "Font Name"
@@ -156,7 +158,8 @@ msgstr "Nom de la police"
 
 #: data/io.github.herve4m.Length.gschema.xml.in:81
 msgid "The font to use when \"use-default-font\" is FALSE."
-msgstr "Police à utiliser quand \"use-default-font\" est FAUX."
+msgstr ""
+"Police à utiliser quand l’option \"use-default-font\" est définie sur FAUX."
 
 #: data/io.github.herve4m.Length.gschema.xml.in:88
 msgid "Window Size"
@@ -172,11 +175,11 @@ msgstr "Utiliser le jeu de couleurs par défaut"
 
 #: data/io.github.herve4m.Length.gschema.xml.in:97
 msgid "Whether to use the default color scheme"
-msgstr "Utiliser ou non le jeu de couleurs par défaut"
+msgstr "Indique s’il faut utiliser ou non le jeu de couleurs par défaut"
 
 #: data/io.github.herve4m.Length.gschema.xml.in:102
 msgid "Foreground Color"
-msgstr "Couleur d'avant-plan"
+msgstr "Couleur d’avant-plan"
 
 #: data/io.github.herve4m.Length.gschema.xml.in:103
 msgid "Color (red, green, blue, alpha) for the ruler ticks and the labels"
@@ -184,11 +187,11 @@ msgstr "Couleur (rouge, vert, bleu, alpha) des marques sur la règle"
 
 #: data/io.github.herve4m.Length.gschema.xml.in:110
 msgid "Background Color"
-msgstr "Couleur d'arrière-plan"
+msgstr "Couleur d’arrière-plan"
 
 #: data/io.github.herve4m.Length.gschema.xml.in:111
 msgid "Color (red, green, blue, alpha) for the ruler background"
-msgstr "Couleur (rouge, vert, bleu, alpha) d'arrière-plan de la règle"
+msgstr "Couleur (rouge, vert, bleu, alpha) d’arrière-plan de la règle"
 
 #: data/ui/help-overlay.ui:30
 msgctxt "shortcut window"
@@ -223,12 +226,12 @@ msgstr "Opacité"
 #: data/ui/help-overlay.ui:66
 msgctxt "shortcut window"
 msgid "Increase Opacity"
-msgstr "Augmenter l'opacité"
+msgstr "Augmenter l’opacité"
 
 #: data/ui/help-overlay.ui:72
 msgctxt "shortcut window"
 msgid "Decrease Opacity"
-msgstr "Réduire l'opacité"
+msgstr "Réduire l’opacité"
 
 #: data/ui/help-overlay.ui:81
 msgctxt "shortcut window"
@@ -238,12 +241,12 @@ msgstr "Suivi du pointeur"
 #: data/ui/help-overlay.ui:84
 msgctxt "shortcut window"
 msgid "Activate/Deactivate"
-msgstr "Activer/Désactiver"
+msgstr "Activer / Désactiver"
 
 #: data/ui/help-overlay.ui:90
 msgctxt "shortcut window"
 msgid "Lock/Unlock Position"
-msgstr "Vérouiller/Dévérouiller la position"
+msgstr "Verrouiller / Déverrouiller la position"
 
 #: data/ui/help-overlay.ui:99
 msgctxt "shortcut window"
@@ -282,24 +285,23 @@ msgstr "Pourcentages"
 
 #: data/ui/offset.ui:30
 msgid "_Offset"
-msgstr "_Offset"
+msgstr "_Décalage"
 
 #: data/ui/opacity.ui:30 data/ui/opacity.ui:48
 msgid "Opacity"
 msgstr "Opacité"
 
 #: data/ui/orientation.ui:30
-#, fuzzy
 msgid "O_rientation"
-msgstr "_Direction"
+msgstr "O_rientation"
 
 #: data/ui/orientation.ui:46
 msgid "Horizontal"
-msgstr "Horizontal"
+msgstr "Horizontale"
 
 #: data/ui/orientation.ui:53
 msgid "Vertical"
-msgstr "Vertical"
+msgstr "Verticale"
 
 #: data/ui/pointer_tracking.ui:30
 msgid "_Track Pointer"
@@ -307,7 +309,7 @@ msgstr "Suivre le poin_teur"
 
 #: data/ui/preferences_display.ui:27
 msgid "Compute Monitor Size"
-msgstr "Calculer la taille de l'écran"
+msgstr "Calculer la taille de l’écran"
 
 #: data/ui/preferences_display.ui:34
 msgid "Custom Monitor Size in Inches"
@@ -335,7 +337,7 @@ msgstr "Apparence"
 
 #: data/ui/preferences.ui:85
 msgid "Use Default _Colors"
-msgstr "Utiliser la _couleur par défaut"
+msgstr "Utiliser les _couleurs par défaut"
 
 #: data/ui/preferences.ui:97
 msgid "Foreground"
@@ -379,7 +381,7 @@ msgstr "_Aide"
 
 #: data/ui/window.ui:116
 msgid "_About Length"
-msgstr "À propos de Length"
+msgstr "À propos de Longueur"
 
 #: data/ui/window.ui:122
 msgid "_Quit"
@@ -387,7 +389,7 @@ msgstr "_Quitter"
 
 #: src/draw_context.py:135
 msgid "Monitor Size Unknown"
-msgstr "Taille d'écran inconnue"
+msgstr "Taille d’écran inconnue"
 
 #: src/draw_context.py:138
 #, python-brace-format
@@ -396,13 +398,13 @@ msgid ""
 "Use the Preferences dialog to calibrate Length for your monitor size.\n"
 "In the meantime, computations are done for a "
 msgstr ""
-"La taille de l'écran {monitor_name} ne peut être calculée.\n"
-"Utiliser les Préférences pour calibrer Length pour votre taille d'écran.\n"
+"La taille de l’écran {monitor_name} ne peut être calculée.\n"
+"Utilisez les Préférences pour calibrer Longueur pour votre taille d’écran.\n"
 "En attendant, les calculs sont faits pour un écran de "
 
 #: src/draw_context.py:146
 msgid "OK"
-msgstr "OK"
+msgstr "D’accord"
 
 #. Translators: Replace "translator-credits" with your name/username,
 #. and optionally an email or URL.


### PR DESCRIPTION
GNOME Translation Team member here :)

I saw a few typos in the UI and wanted to help with translations. As I've noticed you were the first French translator, I would like to have your feedback on the changes I made:
- Translated the app' name (as it's a common noun + _Length_ is difficult to spell in French + it's also translated in the `nl.po` file) 
- `'` → `’`
- spaces → non-breakable spaces (needed for some punctuation marks like `:` or `;`)
- Specified that it's an app that is made _for_ GNOME and not a GNOME app (that could be misleading in the sense that it's not officially developed and distributed by the GNOME desktop devs)
- Took the liberty to rephrase some strings to make it more coherent with other GNOME apps
- Corrected some typos

Overall the translation quality was quite good already! Don't hesitate to tell me if you have a disagreement with some of the changes, these are only proposals