### PR TITLE
Reorganizing the shortcuts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
@@ -12,7 +12,7 @@ repos:
         types:
           - yaml
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 25.9.0
     hooks:
       - id: black
         name: black

--- a/build-aux/flatpak/io.github.herve4m.Length.yaml
+++ b/build-aux/flatpak/io.github.herve4m.Length.yaml
@@ -1,7 +1,7 @@
 ---
 id: io.github.herve4m.Length
 runtime: org.gnome.Platform
-runtime-version: "48"
+runtime-version: "49"
 sdk: org.gnome.Sdk
 command: length
 finish-args:

--- a/help/C/tracking.page
+++ b/help/C/tracking.page
@@ -46,8 +46,6 @@
       <p>
         To lock the position of the tracker, press <key>P</key>.
         Press <key>P</key> again to unlock the tracker.
-        Alternatively, use the middle mouse button to lock and unlock the tracker.
-        In some environments however, the middle mouse button might be associated with another function.
       </p>
     </item>
   </steps>

--- a/help/fr/fr.po
+++ b/help/fr/fr.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2025-08-12 17:09+0200\n"
+"POT-Creation-Date: 2025-09-19 14:22+0200\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
@@ -559,18 +559,13 @@ msgstr "Activer <gui style=\"button\">Suivre le pointeur</gui>."
 #: ../help/C/tracking.page:46
 msgid ""
 "To lock the position of the tracker, press <key>P</key>. Press <key>P</key> "
-"again to unlock the tracker. Alternatively, use the middle mouse button to "
-"lock and unlock the tracker. In some environments however, the middle mouse "
-"button might be associated with another function."
+"again to unlock the tracker."
 msgstr ""
 "Pour vérouiller la position du pointeur, appuyer sur <key>P</key>. Appuyer "
-"sur <key>P</key> de nouveau pour dévérouiller le pointeur. Vous pouvez aussi "
-"utiliser le bouton du milieu de la souris pour vérouiller et dévérouiller le "
-"pointeur. Certains environements utiliser le bouton du milieu de la souris "
-"pour d’autres fonctions."
+"sur <key>P</key> de nouveau pour dévérouiller le pointeur."
 
 #. (itstool) path: page/p
-#: ../help/C/tracking.page:55
+#: ../help/C/tracking.page:53
 msgid "You can also enable and disable the tracker by pressing <key>T</key>."
 msgstr ""
 "Vous pouvez aussi activer et désactiver le suivi du pointeur en appuyant sur "
@@ -744,6 +739,18 @@ msgid ""
 msgstr ""
 "Voir <link xref=\"calibrating\"/> pour configurer <app>Longueur</app> pour "
 "la taille de votre écran."
+
+#~ msgid ""
+#~ "To lock the position of the tracker, press <key>P</key>. Press <key>P</"
+#~ "key> again to unlock the tracker. Alternatively, use the middle mouse "
+#~ "button to lock and unlock the tracker. In some environments however, the "
+#~ "middle mouse button might be associated with another function."
+#~ msgstr ""
+#~ "Pour vérouiller la position du pointeur, appuyer sur <key>P</key>. "
+#~ "Appuyer sur <key>P</key> de nouveau pour dévérouiller le pointeur. Vous "
+#~ "pouvez aussi utiliser le bouton du milieu de la souris pour vérouiller et "
+#~ "dévérouiller le pointeur. Certains environements utiliser le bouton du "
+#~ "milieu de la souris pour d’autres fonctions."
 
 #~ msgid "This work is licensed under a <_:link-1/> license."
 #~ msgstr "Ce travail est sous licence <_:link-1/>."

--- a/help/help.pot
+++ b/help/help.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2025-07-02 20:41+0200\n"
+"POT-Creation-Date: 2025-09-19 14:22+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -379,7 +379,7 @@ msgstr ""
 
 #. (itstool) path: page/p
 #: ../help/C/rotating.page:47
-msgid "You can also change the orientation of the ruler by dragging its corners."
+msgid "You can also change the orientation of the ruler by dragging its corners or by clicking the mouse middle button."
 msgstr ""
 
 #. (itstool) path: page/title
@@ -449,11 +449,11 @@ msgstr ""
 
 #. (itstool) path: item/p
 #: ../help/C/tracking.page:46
-msgid "To lock the position of the tracker, press <key>P</key>. Press <key>P</key> again to unlock the tracker. Alternatively, use the middle mouse button to lock and unlock the tracker. In some environments however, the middle mouse button might be associated with another function."
+msgid "To lock the position of the tracker, press <key>P</key>. Press <key>P</key> again to unlock the tracker."
 msgstr ""
 
 #. (itstool) path: page/p
-#: ../help/C/tracking.page:55
+#: ../help/C/tracking.page:53
 msgid "You can also enable and disable the tracker by pressing <key>T</key>."
 msgstr ""
 

--- a/src/orientation.py
+++ b/src/orientation.py
@@ -47,14 +47,26 @@ class OrientationControl(Gtk.Box):
         if w == 0 or h == 0:
             w, h = self.application_window.get_default_size()
 
-        # Although the window should automatically change size when
-        # setting the default size, it is not always the case. As a
-        # workaround, maximizing, unmaximizing, and presenting the
-        # window does the trick.
+        # You cannot programmatically rotate the window with Gtk 4.
+        # As a messy workaround, maximizing, unmaximizing, and
+        # presenting the window does the trick. See
+        # https://discourse.gnome.org/t/programmatically-set-window-size/31339/6
         self.application_window.set_default_size(h, w)
         self.application_window.maximize()
         self.application_window.unmaximize()
         self.application_window.present()
+
+        if (
+            self.application_window.context.track_pointer
+            and self.application_window.context.track_locked
+        ):
+            (
+                self.application_window.context.track_pos_x,
+                self.application_window.context.track_pos_y,
+            ) = (
+                self.application_window.context.track_pos_y,
+                self.application_window.context.track_pos_x,
+            )
 
     @Gtk.Template.Callback()
     def _orientation_toggled(self, toggle) -> None:

--- a/src/window.py
+++ b/src/window.py
@@ -206,6 +206,10 @@ class LengthWindow(Adw.ApplicationWindow):
                 self.context.track_pos_x = self.context.pointer_x
                 self.context.track_pos_y = self.context.pointer_y
                 self.drawing_area.queue_draw()
+        #
+        # You cannot programmatically rotate the window with Gtk 4. See
+        # https://discourse.gnome.org/t/programmatically-set-window-size/31339/6
+        #
         # elif key_val == Gdk.KEY_r:
         #     self.orientation_control.rotate()
 
@@ -235,12 +239,6 @@ class LengthWindow(Adw.ApplicationWindow):
 
     @Gtk.Template.Callback()
     def _on_button_pressed_event(self, gesture, n_press: int, x: float, y: float) -> None:
-        # Middle button
+        # Rotate on middle button click
         if gesture.get_current_button() == 2:
-            if self.context.track_pointer:
-                self.context.track_locked = not self.context.track_locked
-                self.context.track_pos_x = x
-                self.context.track_pos_y = y
-                self.drawing_area.queue_draw()
-            else:
-                self.orientation_control.rotate()
+            self.orientation_control.rotate()


### PR DESCRIPTION
Partially fixes issue #44.

**Previously**, the middle mouse button served two purposes:
* Changing the orientation of the ruler.
* Locking the tracker position when tracking was enabled. In that case, using the middle button would lock/unlock the tracker, instead of changing the ruler orientation.

This causes an issue when you want to change the orientation of the ruler while the tracker is locked: you cannot use the middle button, because that would unlock the tracker instead.
In that case you have to use the menu to change the orientation, which is not handy.

**With this fix**, the middle mouse button is solely used to change the ruler's orientation.
You cannot lock the tracker position with the middle button anymore, and you must use the shortcut (p) for that purpose.

An other option would have been to create a keyboard shortcut (the `R` key for example) to change the ruler's orientation. However, the toolkit (GTK 4) does not allow to programmatically change the window size. 
